### PR TITLE
Implement basic Bear note organizer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,25 @@
-this is the project
+# Kstatus
+
+A simple command-line tool for organizing notes stored in the [Bear](https://bear.app/) application. Notes can be grouped by tag, title, or date using the Bear API.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set environment variables for the Bear API:
+   - `BEAR_API_URL` - Base URL of the Bear API (defaults to `https://api.bear.app`).
+   - `BEAR_API_TOKEN` - Personal access token used for authentication.
+
+## Usage
+
+Run the command-line tool from the project root:
+
+```bash
+python -m src.main --by tag          # group notes by their first tag
+python -m src.main --by title        # group notes alphabetically by title
+python -m src.main --by date --date-key modified   # group by modified date
+```
+
+The command prints categorized notes in JSON format.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Bear note organizer package."""

--- a/src/bear_api.py
+++ b/src/bear_api.py
@@ -1,0 +1,20 @@
+import os
+from typing import List, Dict
+import requests
+
+class BearAPI:
+    """Simple Bear API client."""
+
+    def __init__(self, token: str | None = None) -> None:
+        self.token = token or os.environ.get("BEAR_API_TOKEN", "")
+        self.base_url = os.environ.get("BEAR_API_URL", "https://api.bear.app")
+        self.session = requests.Session()
+        if self.token:
+            self.session.headers.update({"Authorization": f"Bearer {self.token}"})
+
+    def get_notes(self) -> List[Dict]:
+        """Retrieve notes from Bear API."""
+        url = f"{self.base_url}/notes"
+        response = self.session.get(url)
+        response.raise_for_status()
+        return response.json().get("notes", [])

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,39 @@
+"""Command line interface for organizing Bear notes."""
+import argparse
+import json
+from .bear_api import BearAPI
+from .organizer import (
+    categorize_by_tag,
+    categorize_by_title,
+    categorize_by_date,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Organize Bear notes")
+    parser.add_argument(
+        "--by",
+        choices=["tag", "title", "date"],
+        default="tag",
+        help="Categorization method",
+    )
+    parser.add_argument(
+        "--date-key", default="created", help="Date field to use when --by date"
+    )
+    args = parser.parse_args()
+
+    api = BearAPI()
+    notes = api.get_notes()
+
+    if args.by == "tag":
+        categories = categorize_by_tag(notes)
+    elif args.by == "title":
+        categories = categorize_by_title(notes)
+    else:
+        categories = categorize_by_date(notes, date_key=args.date_key)
+
+    print(json.dumps(categories, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/organizer.py
+++ b/src/organizer.py
@@ -1,0 +1,31 @@
+from collections import defaultdict
+from typing import List, Dict
+
+
+def categorize_by_tag(notes: List[Dict]) -> Dict[str, List[Dict]]:
+    """Group notes by their first tag."""
+    categories: Dict[str, List[Dict]] = defaultdict(list)
+    for note in notes:
+        tags = note.get("tags", [])
+        key = tags[0] if tags else "untagged"
+        categories[key].append(note)
+    return categories
+
+
+def categorize_by_title(notes: List[Dict]) -> Dict[str, List[Dict]]:
+    """Group notes alphabetically by their title."""
+    categories: Dict[str, List[Dict]] = defaultdict(list)
+    for note in notes:
+        title = note.get("title", "").strip()
+        key = title[0].upper() if title else "?"
+        categories[key].append(note)
+    return categories
+
+
+def categorize_by_date(notes: List[Dict], date_key: str = "created") -> Dict[str, List[Dict]]:
+    """Group notes by a date field (created or modified)."""
+    categories: Dict[str, List[Dict]] = defaultdict(list)
+    for note in notes:
+        date = note.get(date_key, "unknown")
+        categories[str(date)].append(note)
+    return categories


### PR DESCRIPTION
## Summary
- structure project under `src/`
- add simple Bear API client and note organizer
- implement CLI entrypoint
- document setup and usage

## Testing
- `pip install -r requirements.txt`
- `python -m src.main --by tag` *(fails: 503 Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_6840a5bddbc4832392c03d36a17ad5c2