### PR TITLE
Add CLI output option and error handling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,4 +22,8 @@ python -m src.main --by title        # group notes alphabetically by title
 python -m src.main --by date --date-key modified   # group by modified date
 ```
 
-The command prints categorized notes in JSON format.
+The command prints categorized notes in JSON format by default. Use `--output PATH`
+to write the JSON to a file instead.
+
+If the tool fails to retrieve notes from the Bear API, it prints `failed to fetch
+notes` and exits with a non-zero status code.

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,8 @@
 """Command line interface for organizing Bear notes."""
 import argparse
 import json
+import sys
+import requests
 from .bear_api import BearAPI
 from .organizer import (
     categorize_by_tag,
@@ -20,10 +22,18 @@ def main() -> None:
     parser.add_argument(
         "--date-key", default="created", help="Date field to use when --by date"
     )
+    parser.add_argument(
+        "--output",
+        help="Path to file where JSON output will be written",
+    )
     args = parser.parse_args()
 
     api = BearAPI()
-    notes = api.get_notes()
+    try:
+        notes = api.get_notes()
+    except requests.exceptions.HTTPError:
+        print("failed to fetch notes")
+        sys.exit(1)
 
     if args.by == "tag":
         categories = categorize_by_tag(notes)
@@ -32,7 +42,12 @@ def main() -> None:
     else:
         categories = categorize_by_date(notes, date_key=args.date_key)
 
-    print(json.dumps(categories, indent=2))
+    result_json = json.dumps(categories, indent=2)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(result_json)
+    else:
+        print(result_json)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- handle `requests.exceptions.HTTPError` when fetching notes
- add `--output` CLI option to write JSON to a file
- document new option and error behaviour in the README

## Testing
- `python -m src.main --help`
- `BEAR_API_URL=https://httpbin.org/status/404 python -m src.main --by tag`
- `BEAR_API_URL=https://httpbin.org/anything python -m src.main --output /tmp/test_out.json`

------
https://chatgpt.com/codex/tasks/task_e_6840a6ffa3b48323bc38f2881c0aabe9